### PR TITLE
docs: add OpenGoat→Antfarm bridge smoke test checklist

### DIFF
--- a/docs/opengoat-antfarm-bridge-smoke.md
+++ b/docs/opengoat-antfarm-bridge-smoke.md
@@ -1,0 +1,25 @@
+# OpenGoat-to-Antfarm Dispatch Bridge Smoke Test
+
+OpenGoatTask: `task-bridge-smoke-opengoat-to-antfarm-dispatch-f31a05a2`
+
+## Overview
+The OpenGoat-to-Antfarm dispatch bridge forwards a task trigger from OpenGoat into an Antfarm workflow run. This smoke test verifies the end-to-end integration at a high level so the team can quickly confirm that dispatch, execution handoff, and completion signaling still work after changes.
+
+## Bridge Smoke Test Description
+1. Trigger the bridge smoke test task from OpenGoat.
+2. Confirm Antfarm creates a run from the dispatched task.
+3. Confirm an agent claims the step and receives the expected input.
+4. Confirm the step result is reported with the required `KEY: value` output format and `STATUS: done`.
+5. Confirm the run advances to completion without manual intervention.
+
+## Acceptance Checklist
+- [ ] Dispatch trigger from OpenGoat initiates the workflow run correctly.
+- [ ] Dispatched task payload is well-formed (required fields, IDs, and input content are present).
+- [ ] Antfarm receives the task and acknowledges it by creating/claiming the expected step.
+- [ ] Error handling is verified when Antfarm is unreachable (failure is surfaced clearly and does not hang silently).
+- [ ] Dispatch is idempotent for repeated trigger attempts (no duplicate or inconsistent runs beyond expected behavior).
+- [ ] Logging and observability are sufficient to trace dispatch, claim, execution, and completion events.
+
+## Notes
+- This is a smoke test, not an exhaustive integration test.
+- Use this checklist for quick validation during bridge changes, release readiness, or incident triage.

--- a/progress-e32703f2-dd63-4dff-b8b2-92b599d49348.txt
+++ b/progress-e32703f2-dd63-4dff-b8b2-92b599d49348.txt
@@ -1,0 +1,17 @@
+# Progress Log
+Run: e32703f2-dd63-4dff-b8b2-92b599d49348
+Task: Add docs/opengoat-antfarm-bridge-smoke.md describing bridge smoke test and acceptance checklist
+Started: 2026-02-27 09:31 CET
+
+## Codebase Patterns
+- Documentation in this repo follows straightforward Markdown structure with clear `##` sections and checkbox lists using `- [ ]`.
+- Docs validation tests are lightweight pytest checks that read Markdown files and assert required headings/checklist markers.
+
+---
+
+## 2026-02-27 09:31 CET - US-001: Add docs/opengoat-antfarm-bridge-smoke.md with bridge smoke test description and acceptance checklist
+- Implemented `docs/opengoat-antfarm-bridge-smoke.md` with required sections: Overview, Bridge Smoke Test Description, Acceptance Checklist, and Notes.
+- Added acceptance checklist items covering dispatch trigger, payload format, Antfarm acknowledgement, unreachable Antfarm error handling, idempotency, and logging/observability.
+- Added `tests/test_docs_bridge_smoke.py` to validate file existence, UTF-8 readability, required headings, and checklist item presence.
+- **Learnings:** Existing quality checks in this repo can be run directly via `.venv/bin/mypy` and `.venv/bin/pytest`.
+---

--- a/tests/test_docs_bridge_smoke.py
+++ b/tests/test_docs_bridge_smoke.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+DOC_PATH = Path("docs/opengoat-antfarm-bridge-smoke.md")
+
+
+def test_bridge_smoke_doc_exists_and_utf8() -> None:
+    assert DOC_PATH.exists(), "Expected bridge smoke doc to exist"
+    DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_bridge_smoke_doc_has_required_headings() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    top_level = next((line for line in lines if line.startswith("# ")), "")
+    assert "OpenGoat" in top_level and "Bridge" in top_level
+
+    assert "## Overview" in text
+    assert "## Bridge Smoke Test Description" in text
+    assert "## Acceptance Checklist" in text
+
+
+def test_bridge_smoke_doc_has_checklist_items() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    checklist_items = [line for line in text.splitlines() if line.startswith("- [ ]")]
+    assert len(checklist_items) >= 3


### PR DESCRIPTION
## Summary
Add a docs-only bridge smoke test guide for OpenGoat to Antfarm dispatch validation.

### What changed
- Added `docs/opengoat-antfarm-bridge-smoke.md` with sections: Overview, Bridge Smoke Test Description, Acceptance Checklist, and Notes
- Documented checklist coverage for dispatch trigger, payload format, Antfarm acknowledgement, unreachable-Antfarm error handling, idempotency, and logging/observability
- Added `tests/test_docs_bridge_smoke.py` to validate document presence, UTF-8 validity, required headings, and checklist entries

## Why
Provide a clear, repeatable smoke-test contract for the OpenGoat→Antfarm bridge and enforce docs completeness via tests.

## Testing
- Ran `.venv/bin/pytest -q`
- Result: 3 passed, 0 failed
