### PR TITLE
Establish repository hygiene baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.env
+node_modules/
+*.key
+*.pem
+*.secret
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.mypy_cache/
+.venv/
+venv/
+env/
+dist/
+.DS_Store
+*.log
+progress-*.txt

--- a/docs/repo-hygiene.md
+++ b/docs/repo-hygiene.md
@@ -1,0 +1,17 @@
+# Repository Hygiene
+
+Quick reference for keeping this repository clean and safe.
+
+## Ignored Paths
+
+The `.gitignore` excludes local/runtime artifacts so commits stay portable and reviewable:
+
+- `progress-*.txt` for local workflow progress artifacts
+- Python caches such as `__pycache__/`, `*.py[cod]`, `.pytest_cache/`, and `.mypy_cache/`
+- Local virtual environments such as `.venv/`, `venv/`, and `env/`
+
+## Rules
+
+- Never commit progress files or other local run artifacts.
+- Keep virtual environments local and out of version control.
+- Never commit secrets (for example `.env`, `*.key`, `*.pem`, `*.secret`).

--- a/tests/test_docs_repo_hygiene.py
+++ b/tests/test_docs_repo_hygiene.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+
+DOC_PATH = Path("docs/repo-hygiene.md")
+
+
+def test_repo_hygiene_doc_exists_and_is_utf8() -> None:
+    assert DOC_PATH.exists(), "Expected docs/repo-hygiene.md to exist"
+    text = DOC_PATH.read_text(encoding="utf-8")
+    assert isinstance(text, str)
+
+
+def test_repo_hygiene_doc_has_required_headings() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+
+    assert "# Repository Hygiene" in text
+    assert "## Ignored Paths" in text
+    assert "## Rules" in text
+
+
+def test_repo_hygiene_doc_has_at_least_three_rules_bullets() -> None:
+    text = DOC_PATH.read_text(encoding="utf-8")
+    lines = text.splitlines()
+
+    rules_start = lines.index("## Rules") + 1
+
+    rules_section: list[str] = []
+    for line in lines[rules_start:]:
+        if line.startswith("## "):
+            break
+        rules_section.append(line)
+
+    bullet_lines = [
+        line for line in rules_section if line.strip().startswith("- ") or line.strip().startswith("* ")
+    ]
+    assert len(bullet_lines) >= 3, "Expected at least 3 bullet-point rules under ## Rules"

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+def _gitignore_lines() -> set[str]:
+    text = Path('.gitignore').read_text(encoding='utf-8')
+    return {line.strip() for line in text.splitlines() if line.strip() and not line.strip().startswith('#')}
+
+
+def test_gitignore_contains_progress_and_python_patterns() -> None:
+    lines = _gitignore_lines()
+
+    required_patterns = {
+        'progress-*.txt',
+        '__pycache__/',
+        '*.py[cod]',
+        '.pytest_cache/',
+        '.mypy_cache/',
+        '.venv/',
+    }
+
+    missing = sorted(required_patterns - lines)
+    assert not missing, f'Missing .gitignore patterns: {missing}'


### PR DESCRIPTION
## Summary\n- remove tracked progress-*.txt artifacts from git tracking\n- update .gitignore to ignore progress-*.txt and Python cache/venv paths\n- add docs/repo-hygiene.md with concise repository hygiene rules\n- add tests/test_docs_repo_hygiene.py to validate docs structure and rule coverage\n\n## Why\nSet a safe, minimal repository hygiene baseline so generated progress artifacts and local Python environment files are not tracked, while documenting and enforcing expectations.\n\n## Testing\n- python3 -m compileall .\n- .venv/bin/python -m pytest -q